### PR TITLE
Llvm plugin

### DIFF
--- a/llvm_plugin/CMakeLists.txt
+++ b/llvm_plugin/CMakeLists.txt
@@ -3,8 +3,8 @@ include(AddLLVM)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_compile_options(-Wall -Werror -Wconversion -Wsign-conversion -Wpedantic
-                    -Wvla)
+add_compile_options(-Wall -Werror -Wconversion -Wsign-conversion 
+                    -Wpedantic -Wvla)
 
 add_llvm_pass_plugin(LLVMCfip MODULE
   cfip.cpp

--- a/llvm_plugin/cfip.cpp
+++ b/llvm_plugin/cfip.cpp
@@ -2,7 +2,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
-#include <functional>
+#include "llvm/Transforms/Scalar/Reg2Mem.h"
 
 using namespace llvm;
 #define DEBUG_TYPE "cfip"
@@ -36,7 +36,9 @@ llvm::PassPluginLibraryInfo getCfipPluginInfo() {
                 [](StringRef Name, FunctionPassManager &FPM,
                    ArrayRef<PassBuilder::PipelineElement>) {
                   if (Name == "cfip") {
+                    FPM.addPass(RegToMemPass());
                     FPM.addPass(Cfip());
+                    return true;
                   }
                   return false;
                 });

--- a/llvm_plugin/cfip.cpp
+++ b/llvm_plugin/cfip.cpp
@@ -1,5 +1,6 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -166,10 +167,15 @@ size_t harden_fn(Function &function) {
 
 struct Cfip : PassInfoMixin<Cfip> {
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
-    if (harden_fn(F))
+    if (harden_fn(F)) {
+      // otherwise our hardening will be optimized out
+      F.addFnAttr(Attribute::OptimizeNone);
+      // required be OptimizeNone
+      F.addFnAttr(Attribute::NoInline);
       return PreservedAnalyses::none();
-    else
+    } else {
       return PreservedAnalyses::all();
+    }
   }
 
   static bool isRequired() { return true; }

--- a/llvm_plugin/cfip.cpp
+++ b/llvm_plugin/cfip.cpp
@@ -5,6 +5,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Transforms/Scalar/Reg2Mem.h"
+#include "llvm/Transforms/Scalar/SROA.h"
 
 using namespace llvm;
 #define DEBUG_TYPE "cfip"
@@ -180,6 +181,7 @@ llvm::PassPluginLibraryInfo getCfipPluginInfo() {
                     // consider removing this later
                     FPM.addPass(RegToMemPass());
                     FPM.addPass(Cfip());
+                    FPM.addPass(SROAPass(SROAOptions::ModifyCFG));
                     return true;
                   }
                   return false;

--- a/llvm_plugin/cfip.cpp
+++ b/llvm_plugin/cfip.cpp
@@ -174,6 +174,7 @@ llvm::PassPluginLibraryInfo getCfipPluginInfo() {
                 [](StringRef Name, FunctionPassManager &FPM,
                    ArrayRef<PassBuilder::PipelineElement>) {
                   if (Name == "cfip") {
+                    // consider removing this later
                     FPM.addPass(RegToMemPass());
                     FPM.addPass(Cfip());
                     return true;

--- a/rust_attribute/src/lib.rs
+++ b/rust_attribute/src/lib.rs
@@ -57,7 +57,7 @@ fn harden_init(stmt_init: &mut syn::LocalInit) {
                         #[inline(never)]
                         #[unsafe(no_mangle)]
                         fn #function_name<T>(dummy: T) -> T {
-                            use std::hint::black_box;
+                            use core::hint::black_box;
                             return black_box(dummy);
                         }
                         #function_name(#new_init)


### PR DESCRIPTION
example, the plugin transforms:
```llvm
define dso_local i32 @main() local_unnamed_addr #0 {
  %1 = tail call i32 @internal_cfip_opaque_call_(i32 noundef 1337) #2
  %2 = add i32 %1, 2
  ret i32 %2
}
```
into:
```llvm
define dso_local i32 @main() local_unnamed_addr #4 {
  %1 = add i32 1337, 2
  %2 = add i32 1337, 2
  %is_fault_detected = icmp ne i32 %1, %2
  %3 = or i1 false, %is_fault_detected
  br i1 %3, label %error_handling, label %ret_block, !prof !0

ret_block:                                        ; preds = %0
  ret i32 %1

error_handling:                                   ; preds = %0
  call void @llvm.trap()
  unreachable
}

!0 = !{!"branch_weights", !"expected", i32 1, i32 2000}

```
